### PR TITLE
Add SDE testing to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - curl --verbose
        --cookie jar.txt
        --output sde.tar.bz2
-       https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
+       https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
 - export SDE_DIR=$(mktemp)
 - tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 
 # run tests inside SDE
 - go test -c
-- for chip in hsw icl future; do ${SDE_BIN} -${SDE_CHIP} -- ./meow.test -test.v; done
+- for chip in hsw icl future; do ${SDE_BIN} -${chip} -- ./meow.test -test.v; done
 
 # ensure we can build the testvector generator
 - make -C testdata distclean testvectors

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
        https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
 - tar -xf sde.tar.bz2
 - export SDE_BIN="$(pwd -P)/${SDE_VERSION_NAME}/sde64"
-- ! ${SDE_BIN} -help
 script:
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
 - SDE_CHIP=hsw
 - SDE_CHIP=icl
 install:
-- export SDE_VERSION_NAME="sde-external-8.16.0-2018-01-30-lin"
 - curl --verbose
        --form accept_license=1
        --form form_id=intel_licensed_dls_step_1
@@ -17,9 +16,13 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
-- tar xf sde.tar.bz2
-- export PATH="${PATH}:${TRAVIS_BUILD_DIR}/${SDE_VERSION_NAME}"
+- export SDE_DIR=$(mktemp)
+- tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
 script:
+- ls -l ${SDE_DIR}
+- export PATH="${PATH}:${SDE_DIR}"
+- which sde
+
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)
 - cp block_amd64.s ${block}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 env:
 - SDE_CHIP=icl
 install:
+- export "SDE_VERSION_NAME=sde-external-8.16.0-2018-01-30-lin"
 - curl --verbose
        --form accept_license=1
        --form form_id=intel_licensed_dls_step_1
@@ -14,14 +15,10 @@ install:
 - curl --verbose
        --cookie jar.txt
        --output sde.tar.bz2
-       https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
+       https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
 - tar -xf sde.tar.bz2
-- ls -l
+- export SDE_DIR="$(pwd -P)/${SDE_VERSION_NAME}"
 script:
-- ls -l ${SDE_DIR}
-- export PATH="${PATH}:${SDE_DIR}"
-- which sde
-
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)
 - cp block_amd64.s ${block}
@@ -36,7 +33,7 @@ script:
 
 # run tests inside SDE
 - go test -c
-- sde -${SDE_CHIP} -- ./meow.test -test.v
+- ${SDE_DIR}/sde -${SDE_CHIP} -- ./meow.test -test.v
 
 # ensure we can build the testvector generator
 - make -C testdata distclean testvectors

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
 - 1.x
 env:
-- SDE_CHIP=hsw
 - SDE_CHIP=icl
 install:
 - curl --verbose
@@ -16,6 +15,7 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
+- tar -xzf sde.tar.bz2
 - ls -l
 script:
 - ls -l ${SDE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
        https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
 - tar -xf sde.tar.bz2
 - export SDE_BIN="$(pwd -P)/${SDE_VERSION_NAME}/sde64"
+- ${SDE_BIN} -help
 script:
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
-- export SDE_DIR="$(pwd)/sde"
-- mkdir -p ${SDE_DIR}; tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
+- ls -l
 script:
 - ls -l ${SDE_DIR}
 - export PATH="${PATH}:${SDE_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
 - tar -xf sde.tar.bz2
-- export SDE_DIR="$(pwd -P)/${SDE_VERSION_NAME}"
+- export SDE_BIN="$(pwd -P)/${SDE_VERSION_NAME}/sde64"
 script:
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)
@@ -33,7 +33,7 @@ script:
 
 # run tests inside SDE
 - go test -c
-- ${SDE_DIR}/sde -${SDE_CHIP} -- ./meow.test -test.v
+- ${SDE_BIN} -${SDE_CHIP} -- ./meow.test -test.v
 
 # ensure we can build the testvector generator
 - make -C testdata distclean testvectors

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
-- export SDE_DIR=$(mktemp)
+- export SDE_DIR=$(mktemp -d)
 - tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
 script:
 - ls -l ${SDE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
-- export SDE_DIR=$(mktemp -d)
-- tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
+- export SDE_DIR="$(pwd)/sde"
+- mkdir -p ${SDE_DIR}; tar -xf -C ${SDE_DIR} --strip-components=1 sde.tar.bz2
 script:
 - ls -l ${SDE_DIR}
 - export PATH="${PATH}:${SDE_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go:
 - 1.x
-env:
-- SDE_CHIP=icl
 install:
 - export "SDE_VERSION_NAME=sde-external-8.16.0-2018-01-30-lin"
 - curl --verbose
@@ -33,7 +31,7 @@ script:
 
 # run tests inside SDE
 - go test -c
-- ${SDE_BIN} -${SDE_CHIP} -- ./meow.test -test.v
+- for chip in hsw icl future; do ${SDE_BIN} -${SDE_CHIP} -- ./meow.test -test.v; done
 
 # ensure we can build the testvector generator
 - make -C testdata distclean testvectors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,41 @@
 language: go
 go:
 - 1.x
+env:
+- SDE_CHIP=hsw
+- SDE_CHIP=icl
+install:
+- export SDE_VERSION_NAME="sde-external-8.16.0-2018-01-30-lin"
+- curl --verbose
+       --form accept_license=1
+       --form form_id=intel_licensed_dls_step_1
+       --output /dev/null
+       --cookie-jar jar.txt
+       --location
+       https://software.intel.com/protected-download/267266/144917
+- curl --verbose
+       --cookie jar.txt
+       --output sde.tar.bz2
+       https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
+- tar xf sde.tar.bz2
+- export PATH="${PATH}:${TRAVIS_BUILD_DIR}/${SDE_VERSION_NAME}"
 script:
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)
 - cp block_amd64.s ${block}
 - go generate -x
 - cmp block_amd64.s ${block}
-# run tests
-- go test -v
+
 # test fallback
 - go test -v -tags noasm
+
+# run tests
+- go test -v
+
+# run tests inside SDE
+- go test -c
+- sde -${SDE_CHIP} -- ./meow.test -test.v
+
 # ensure we can build the testvector generator
 - make -C testdata distclean testvectors
 - tv=$(mktemp)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
        https://software.intel.com/system/files/managed/2a/1a/${SDE_VERSION_NAME}.tar.bz2
 - tar -xf sde.tar.bz2
 - export SDE_BIN="$(pwd -P)/${SDE_VERSION_NAME}/sde64"
-- ${SDE_BIN} -help
+- ! ${SDE_BIN} -help
 script:
 # confirm the generator script is in sync with the assembly file
 - block=$(mktemp)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
        --cookie jar.txt
        --output sde.tar.bz2
        https://software.intel.com/system/files/managed/2a/1a/sde-external-8.16.0-2018-01-30-lin.tar.bz2
-- tar -xzf sde.tar.bz2
+- tar -xf sde.tar.bz2
 - ls -l
 script:
 - ls -l ${SDE_DIR}


### PR DESCRIPTION
Adds Intel SDE testing to Travis CI job (for Haswell, Icelake and `future` chip types).

Ideally we would also add CPUID mocking as well (to completely test dispatching). This can come later.

Updates #7 